### PR TITLE
Add missing on_click handler for wx.StaticBitmap to comply with the docs

### DIFF
--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -704,6 +704,8 @@ def staticbitmap(element, instance: wx.StaticBitmap):
     if 'uri' in props:
         bitmap = wx.Bitmap(props.get('uri'))
         instance.SetBitmap(bitmap)
+    if 'on_click' in props:
+        instance.Bind(wx.EVT_LEFT_DOWN, props['on_click'])
     return instance
 
 


### PR DESCRIPTION
on_click was missing but is supposed to exist according to the docs https://github.com/chriskiehl/re-wx/blob/main/docs/supported-wx-components.md#StaticBitmap

I also need the on_click handler on a bitmap in my project.