### PR TITLE
Fix ToggleButtons

### DIFF
--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -124,7 +124,7 @@ def button(element, instance: wx.Button):
 
 @mount.register(wx.ToggleButton)
 def togglebutton(element, parent):
-    return wx.ToggleButton(parent)
+    return update(element, wx.ToggleButton(parent))
 
 
 @update.register(wx.ToggleButton)


### PR DESCRIPTION
ToggleButtons currently do not show labels and do not call the on_click handler.
This is the one line fix.