### PR TITLE
Assorted improvements

### DIFF
--- a/docs/supported-wx-components.md
+++ b/docs/supported-wx-components.md
@@ -1080,7 +1080,7 @@ Displays a Horizontal or Vertical line.
 ```python
 def example(props):
     return wsx(
-      [c.StaticLine, {'style': wx.SL_HORIZONTAL, 'proportion': 1}]
+      [c.StaticLine, {'style': wx.LI_HORIZONTAL, 'flag': wx.EXPAND}]
     )
 ```
 
@@ -1090,7 +1090,7 @@ def example(props):
 
 | key | Type | Description | 
 |------|------|---------|
-|style | str | Text to display at the top of the box | 
+|style | str | [Style flags](https://docs.wxpython.org/wx.StaticLine.html#styles-window-styles) | 
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |

--- a/docs/supported-wx-components.md
+++ b/docs/supported-wx-components.md
@@ -32,7 +32,11 @@ def my_stuff(props):
  * [CheckBox](#CheckBox)
  * [CollapsiblePane](#CollapsiblePane)
  * [ComboBox](#ComboBox)
+ * [DirPickerCtrl](#DirPickerCtrl)
  * [Dropdown](#ComboBox)
+ * [FilePickerCtrlOpen](#FilePickerCtrlOpen)
+ * [FilePickerCtrlSave](#FilePickerCtrlSave)
+ * [FlexGrid](#FlexGrid)
  * [Frame](#Frame)
  * [Gauge](#Gauge)
  * [Grid](#Grid)
@@ -44,6 +48,7 @@ def my_stuff(props):
  * [Panel](#Panel)
  * [RadioBox](#RadioBox)
  * [RadioButton](#RadioButton)
+ * [ScrolledPanel](#ScrolledPanel)
  * [Slider](#Slider)
  * [SpinCtrl](#SpinCtrl)
  * [SpinCtrlDouble](#SpinCtrlDouble)
@@ -137,6 +142,7 @@ def example(props):
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
 |on_click | callable | Calls the supplied function when this element is click. |
+|on_size | callable | Called when the size of the window changes.
 
 
 <br/>
@@ -149,7 +155,7 @@ def example(props):
 </p>
 
 
-Your basic button.
+Your basic [`wx.Button`](https://docs.wxpython.org/wx.Button.html).
 
 **Example:**
 
@@ -158,12 +164,13 @@ def button_example(props):
     return create_element(Button, {'label': 'Click me!', 'on_click': props['handler']})
 ```
 
-**Availble Props:**
+**Available Props:**
 
 
 | key | Type | Description |
 |------|------|---------|
 |label| string | The label displayed on the button |
+|label_markup | string | The label displayed on the button with [`wx.Control.SetLabelMarkup`](https://docs.wxpython.org/wx.Control.html?highlight=setlabelmarkup#wx.Control.SetLabelMarkup) |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |font| wx.Font | Sets the Font used by this component and all of its children|
@@ -322,6 +329,49 @@ def example(props):
 
 <br />
 
+## DirPickerCtrl
+
+Control for choosing a directory path.
+
+A [`wx.DirPickerCtrl`](https://docs.wxpython.org/wx.DirPickerCtrl.html) with
+default style and with an added
+[`wx.FileDropTarget`](https://docs.wxpython.org/wx.FileDropTarget.html) for MS Windows.
+In GTK the `wx.DirPickerCtrl` will accept file drop events.
+
+**Example:**
+
+```python
+return wsx(
+    [ DirPickerCtrl, {
+        'path': '~`,
+        'on_change': handle_path_change,
+        }
+    ],
+```
+
+**Availble Props:**
+
+| key | Type | Description |
+|------|------|---------|
+|label| str | |
+|path | str | The currently selected path, if any.
+|on_change | callable | When the path changes, called with [`wx.FileDirPickerEvent`](https://docs.wxpython.org/wx.FileDirPickerEvent.html).
+|background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
+|foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
+|font| wx.Font | Sets the Font used by this component and all of its children|
+|name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
+|min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
+|max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
+|text_font| `wx.Font` | The font used for the `wx.TextControl` which is displayed for MS Windows.
+|tooltip| str | Displays a string when the user hovers over the component |
+|show| boolean | Toggle whether this item is visible or not. |
+|enabled| boolean | Enables/Disables the component. |
+|proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
+|flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
+|border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
+
+<br />
+
 ## ComboBox
 
 <p align="center">
@@ -362,6 +412,132 @@ def example(props):
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
 
+<br />
+
+## FilePickerCtrlOpen
+
+A [`wx.FilePickerCtrl`](https://docs.wxpython.org/wx.FilePickerCtrl.html)
+with default style `wx.FLP_OPEN | wx.FLP_FILE_MUST_EXIST`.
+
+**Example:**
+
+```python
+return wsx(
+    [ FilePickerCtrlOpen, {
+        'path': '~/file.txt`,
+        'on_change': handle_path_change,
+        }
+    ],
+```
+
+**Availble Props:**
+
+| key | Type | Description |
+|------|------|---------|
+|label| str | |
+|path | str | The currently selected path, if any.
+|on_change | callable | When the path changes, called with [`wx.FileDirPickerEvent`](https://docs.wxpython.org/wx.FileDirPickerEvent.html).
+|background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
+|foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
+|font| wx.Font | Sets the Font used by this component and all of its children|
+|name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
+|min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
+|max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
+|tooltip| str | Displays a string when the user hovers over the component |
+|show| boolean | Toggle whether this item is visible or not. |
+|enabled| boolean | Enables/Disables the component. |
+|proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
+|flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
+|border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
+
+<br />
+
+## FilePickerCtrlSave
+
+A [`wx.FilePickerCtrl`](https://docs.wxpython.org/wx.FilePickerCtrl.html)
+with style `wx.FLP_SAVE`.
+
+**Example:**
+
+```python
+return wsx(
+    [ FilePickerCtrlOpen, {
+        'path': '~/file.txt',
+        'wildcard': '*.txt',
+        'on_change': handle_path_change,
+        }
+    ],
+```
+
+**Availble Props:**
+
+| key | Type | Description |
+|------|------|---------|
+|label| str | |
+|path | str | The currently selected path, if any.
+|on_change | callable | When the path changes, called with [`wx.FileDirPickerEvent`](https://docs.wxpython.org/wx.FileDirPickerEvent.html).
+|background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
+|foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
+|font| wx.Font | Sets the Font used by this component and all of its children|
+|name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
+|min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
+|max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
+|tooltip| str | Displays a string when the user hovers over the component |
+|show| boolean | Toggle whether this item is visible or not. |
+|enabled| boolean | Enables/Disables the component. |
+|proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
+|flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
+|border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
+|wildcard | str | A wildcard which defines user-selectable files. This prop, once set, cannot be changed.
+
+<br />
+
+## FlexGrid
+
+
+Like [Block](#Block), `FlexGrid` is a wrapped version of `wx.Panel` which automatically adds children to an internal [`wx.FlexGridSizer`](https://docs.wxpython.org/wx.FlexGridSizer.html).
+
+The `FlexGridSizer` “lays out its children in a two-dimensional table with all table fields in one row having the same height and all fields in one column having the same width, but all rows or all columns are not necessarily the same height or width as in the `wx.GridSizer`.”
+
+Use this for liquid grid layout like CSS `display:grid;`.
+
+**Example:**
+
+```python
+from components import FlexGrid, StaticText
+
+return wsx(
+    [FlexGrid, {
+        'cols': 2,
+        'gap': wx.Size(8,5),
+        },
+        [StaticText, {'label':'row 1 column 1'}],
+        [StaticText, {'label':'row 1 column 2'}],
+        [StaticText, {'label':'row 2 column 1'}],
+        [StaticText, {'label':'row 2 column 2'}],
+    ])
+```
+
+**Available Props:**
+
+
+| key | Type | Description |
+|------|------|---------|
+|cols| int | The number of columns in the grid |
+|gap| `wx.Size` | the size of the gap between grid items (`(horizontal, vertical)`) |
+|background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
+|foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
+|font| wx.Font | Sets the Font used by this component and all of its children|
+|name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
+|min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
+|max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
+|tooltip| str | Displays a string when the user hovers over the component |
+|show| boolean | Toggle whether this item is visible or not. |
+|enabled| boolean | Enables/Disables the component. |
+|proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
+|flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
+|border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
+|on_click | callable | Calls the supplied function when this element is click. |
 
 <br />
 
@@ -522,7 +698,8 @@ def example(props):
     <img src="https://github.com/chriskiehl/re-wx-images/raw/images/wx_components/listctrl.PNG">
 </p>
 
-The `ListCtrl` in WX, while extremely powerful, has a super awkward and fiddly API. To tame this, re-wx only exposes a subset of the `ListCtrl`'s functionality and wraps it all up in a more declarative, straight forward API geared towards showing tables of information. However, if you need the full, unadultered power of `ListCtrl`, you can always use a `Ref` to grab a handle to the concrete wx instance.
+The [`wx.ListCtrl`](https://docs.wxpython.org/wx.ListCtrl.html),
+while extremely powerful, has a super awkward and fiddly API. To tame this, re-wx only exposes a subset of the `ListCtrl`'s functionality and wraps it all up in a more declarative, straight forward API geared towards showing tables of information. However, if you need the full, unadultered power of `ListCtrl`, you can always use a `Ref` to grab a handle to the concrete wx instance.
 
 
 **Example:**
@@ -807,6 +984,54 @@ def example(props):
 
 
 <br />
+
+## ScrolledPanel
+
+A [`wx.lib.scrolledpanel.ScrolledPanel`](https://docs.wxpython.org/wx.lib.scrolledpanel.ScrolledPanel.html)
+with a `wx.BoxSixer`.
+
+The [`OnChildFocus`](https://docs.wxpython.org/wx.lib.scrolledpanel.ScrolledPanel.html#wx.lib.scrolledpanel.ScrolledPanel.OnChildFocus)
+behavior is disabled.
+
+**Example:**
+
+```python
+wsx([ScrolledPanel, {
+        'scroll_x': False,
+        'scroll_y': True,
+        },
+        [StaticText, {'label': 'Hello world!'}]
+)
+```
+
+
+| key | Type | Description |
+|------|------|---------|
+|orient| int | Controls the direction of the sizer. `wx.HORIZONTAL` or `wx.VERTICAL` |
+|background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
+|foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
+|font| wx.Font | Sets the Font used by this component and all of its children|
+|name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
+|min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
+|max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
+|tooltip| str | Displays a string when the user hovers over the component |
+|show| boolean | Toggle whether this item is visible or not. |
+|enabled| boolean | Enables/Disables the component. |
+|style| any | style is context dependent |
+|proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
+|flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
+|border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
+|scroll_x | bool | `True` to allow horizontal scrolling
+|scroll_y | bool | `True` to allow vertical scrolling
+|rate_x | int | The horizontal scroll increment
+|rate_y | int | The vertical scroll increment
+|on_size | callable | Called when the size of the window changes
+|on_mouse_motion | callable | Called with `wx.MouseEvent` when the mouse position changes
+|on_mouse_wheel | callable | Called with `wx.MouseEvent` when the mouse wheel changes
+|on_scrollwin | callable | Called when the scroll position changes
+
+<br />
+
 
 ## Slider
 

--- a/docs/supported-wx-components.md
+++ b/docs/supported-wx-components.md
@@ -5,16 +5,16 @@
 <h1 align="center">Supported WX Components </h1>
 <br/><br/>
 
-WX Widgets supported and managed by re-wx can all be found in the `rewx.components` module. 
+WX Widgets supported and managed by re-wx can all be found in the `rewx.components` module.
 
-Common practice is to import them under an alias 
+Common practice is to import them under an alias
 
 ```python
-from rewx import components as c 
+from rewx import components as c
 
 ...
 
-def my_stuff(props): 
+def my_stuff(props):
     return wsx(
       [c.Block, {orient:wx.HORIZONTAL},
         [c.TextCtrl, {value: 'Hello!'}]]
@@ -22,7 +22,7 @@ def my_stuff(props):
 ```
 
 
-### Available Components: 
+### Available Components:
 
  * [ActivityIndicator](#ActivityIndicator)
  * [Block](#Block)
@@ -56,13 +56,13 @@ def my_stuff(props):
  * [TextArea](#TextArea)
  * [TextCtrl](#TextCtrl)
  * [ToggleButton](#ToggleButton)
- 
 
 
 
 
 
-## ActivityIndicator 
+
+## ActivityIndicator
 
 <p align="center">
     <img src="https://github.com/chriskiehl/re-wx-images/raw/images/wx_components/activity-indicator.PNG">
@@ -70,24 +70,24 @@ def my_stuff(props):
 
 **Official WXPython docs:**
 
-**Example:** 
+**Example:**
 
 ```
 from components import ActivityIndicator
 
-def example(props): 
+def example(props):
     return create_element(ActivityIndicator, {'start': props['is_loading']})
 ```
 
-**Available Props:** 
+**Available Props:**
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 | start | boolean | Controls whether or not the spinner is animating |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
@@ -95,42 +95,42 @@ def example(props):
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
 |on_click | callable | Calls the supplied function when this element is click. |
- 
+
 
 
 <br/>
 
 ## Block
 
-Block is a wrapped version of `wx.Panel` which automatically adds children to an internal [`wx.BoxSizer()`](https://www.wxpython.org/Phoenix/docs/html/wx.BoxSizer.html). This is the bread and butter of layout control in re-wx. Think of it as a `div` in HTML. 
+Block is a wrapped version of `wx.Panel` which automatically adds children to an internal [`wx.BoxSizer()`](https://www.wxpython.org/Phoenix/docs/html/wx.BoxSizer.html). This is the bread and butter of layout control in re-wx. Think of it as a `div` in HTML.
 
-**Example:** 
+**Example:**
 
 ```python
 from components import Block, TextCtrl, Button
 
 def example(props):
     return wsx(
-      [Block, {'orient': wx.VERTICAL},    
-        [Block, {'orient': wx.HORIZONTAL, 'flag': wx.EXPAND}, 
+      [Block, {'orient': wx.VERTICAL},
+        [Block, {'orient': wx.HORIZONTAL, 'flag': wx.EXPAND},
           [TextCtrl, {'on_change': props['my_handler']}],
           [Button, {'on_click': props['handle_submit']}]]]
     )
 ```
 
-**Available Props:** 
+**Available Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
-|orient| int | Controls the direction of the sizer. `wx.HORIZONTAL` or `wx.VERTICAL` | 
+|orient| int | Controls the direction of the sizer. `wx.HORIZONTAL` or `wx.VERTICAL` |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |font| wx.Font | Sets the Font used by this component and all of its children|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
@@ -141,7 +141,7 @@ def example(props):
 
 <br/>
 
-## Button 
+## Button
 
 
 <p align="center">
@@ -149,7 +149,7 @@ def example(props):
 </p>
 
 
-Your basic button. 
+Your basic button.
 
 **Example:**
 
@@ -161,7 +161,7 @@ def button_example(props):
 **Availble Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |label| string | The label displayed on the button |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
@@ -170,14 +170,14 @@ def button_example(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
@@ -189,7 +189,7 @@ def button_example(props):
 
 <br/>
 
-## BitmapButton 
+## BitmapButton
 
 
 <p align="center">
@@ -198,21 +198,21 @@ def button_example(props):
 
 
 
-BitmapButton is a button which uses an image rather than a text label. Use the `uri` prop to specify the image you want displayed. 
+BitmapButton is a button which uses an image rather than a text label. Use the `uri` prop to specify the image you want displayed.
 
 **Example:**
 
 ```
 def button_example(props):
     return create_element(BitmapButton, {
-        'uri': 'path/to/your/image.png', 
+        'uri': 'path/to/your/image.png',
         'on_click': props['handler']})
 ```
 
 **Availble Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |uri| string | filepath to the image you want displayed. re-wx will handle loading it and turning it into a bitmap |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
@@ -220,79 +220,79 @@ def button_example(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
 <br/>
 
-## CalendarCtrl 
+## CalendarCtrl
 
 <p align="center">
     <img src="https://github.com/chriskiehl/re-wx-images/raw/images/wx_components/calendarctrl.PNG">
 </p>
 
 
-CalendarCtrl is a premade date-picker. 
+CalendarCtrl is a premade date-picker.
 
 **Example:**
 
 ```
 def calendar_example(props):
     return create_element(CalendarCtrl, {
-        'selected_date': datetime.now(), 
+        'selected_date': datetime.now(),
         'on_change': props['handle_change']})
 ```
 
 **Availble Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |selected_date| datetime | sets the value of the date selected in the  widget |
 |display_holidays | boolean | toggles whether or not to display holidays on the calendar|
-|allow_month_change | boolean | controls whether or not the calendar can change to different months | 
-|on_change| callable | Calls the supplied function when the user changes the selected date| 
+|allow_month_change | boolean | controls whether or not the calendar can change to different months |
+|on_change| callable | Calls the supplied function when the user changes the selected date|
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
-<br /> 
+<br />
 
-## CheckBox 
+## CheckBox
 
 <p align="center">
     <img src="https://github.com/chriskiehl/re-wx-images/raw/images/wx_components/checkbox.PNG">
 </p>
 
 
-The humble checkbox. You give it a clickie, it goes on or off. 
+The humble checkbox. You give it a clickie, it goes on or off.
 
 **Example:**
 
 ```
 def example(props):
     return create_element(CheckBox, {
-        'value': True, 
+        'value': True,
         'on_change': props['handle_change']})
 ```
 
@@ -301,18 +301,18 @@ def example(props):
 
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |label| str | The label displayed next to the CheckBox |
 |value| boolean | Whether the checkbox is selected (`True`) or not (`False`) |
-|on_change | callable | Calls the supplied function when the checkbox is clicked | 
+|on_change | callable | Calls the supplied function when the checkbox is clicked |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |font| wx.Font | Sets the Font used by this component and all of its children|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
@@ -320,7 +320,7 @@ def example(props):
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
 
 
-<br /> 
+<br />
 
 ## ComboBox
 
@@ -342,12 +342,12 @@ def example(props):
 
 **Availble Props:**
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |value| str | The value to display in the textctrl part of the dropdown |
 |choices| [str] | A list of strings to display in the dropdown |
-|on_change | callable | Calls the supplied function when an item in the dropdown is selected | 
-|on_input | callable | calls the supplied function when the user types into the textctrl portion of the dropdown | 
+|on_change | callable | Calls the supplied function when an item in the dropdown is selected |
+|on_input | callable | calls the supplied function when the user types into the textctrl portion of the dropdown |
 |style | int | See available styles in the [WXPython docs](https://www.wxpython.org/Phoenix/docs/html/wx.ComboBox.html) |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
@@ -355,7 +355,7 @@ def example(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
@@ -363,7 +363,7 @@ def example(props):
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
 
 
-<br /> 
+<br />
 
 ## Frame
 
@@ -371,7 +371,7 @@ def example(props):
     <img src="https://github.com/chriskiehl/re-wx-images/raw/images/wx_components/frame.PNG">
 </p>
 
-This is the bedrock window to which all other components attach. There must be at least one of these in order for WX to bootstrap its GUI, and should must be at the root of your component tree. 
+This is the bedrock window to which all other components attach. There must be at least one of these in order for WX to bootstrap its GUI, and should must be at the root of your component tree.
 
 **Example:**
 
@@ -380,11 +380,11 @@ def example(props):
     return create_element(Frame, {'title': 'Hello world!'})
 ```
 
-Note: The frame doesn't have to be created or managed by re-wx. Because re-wx outputs vanilla WX objects after `render`ing, you can attach them to an existing frame created elsewhere in the traditional WX manner. 
+Note: The frame doesn't have to be created or managed by re-wx. Because re-wx outputs vanilla WX objects after `render`ing, you can attach them to an existing frame created elsewhere in the traditional WX manner.
 
 ```
-app = wx.App() 
-frame = wx.Frame(None, title='Hello world!') 
+app = wx.App()
+frame = wx.Frame(None, title='Hello world!')
 my_panel = render(my_elements, frame)
 frame.Show()
 app.MainLoop()
@@ -394,11 +394,11 @@ app.MainLoop()
 
 **Availble Props:**
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
-|title| str | The text which displays in the program bar | 
-|show | boolean | Whether or not to show the Frame | 
-|icon_uri | str | File path to the icon to display in the program bar | 
+|title| str | The text which displays in the program bar |
+|show | boolean | Whether or not to show the Frame |
+|icon_uri | str | File path to the icon to display in the program bar |
 |style | int | See available styles in the [WXPython docs](https://www.wxpython.org/Phoenix/docs/html/wx.Frame.html) |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
@@ -406,14 +406,14 @@ app.MainLoop()
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 
 
 
 
 
 
-<br /> 
+<br />
 
 ## Gauge
 
@@ -434,7 +434,7 @@ def example(props):
 
 **Availble Props:**
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |value| int | The the current value of the gauge  |
 |range| int | Sets the maximum value of the gauge |
@@ -446,7 +446,7 @@ def example(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
@@ -469,27 +469,27 @@ def example(props):
 
 ## Grid
 
-Like, [Block](#Block), Grid is a wrapped version of `wx.Panel` which automatically adds children to an internal [`wx.GridSizer()`](https://wxpython.org/Phoenix/docs/html/wx.GridSizer.html). 
+Like, [Block](#Block), Grid is a wrapped version of `wx.Panel` which automatically adds children to an internal [`wx.GridSizer()`](https://wxpython.org/Phoenix/docs/html/wx.GridSizer.html).
 
-**Example:** 
+**Example:**
 
 ```python
 from components import Block, TextCtrl, Button
 
 def example(props):
     return wsx(
-      [Grid, {'orient': wx.VERTICAL},    
+      [Grid, {'orient': wx.VERTICAL},
         [TextCtrl, {'on_change': props['my_handler']}],
         [Button, {'on_click': props['handle_submit']}]]
     )
 ```
 
-**Available Props:** 
+**Available Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
-|cols| int | The number of columns in the grid | 
+|cols| int | The number of columns in the grid |
 |gap|(int, int) | the size of the gap between grid items (`(horizontal, vertical)`) |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
@@ -497,7 +497,7 @@ def example(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
@@ -514,7 +514,7 @@ def example(props):
 
 
 
-<br /> 
+<br />
 
 ## ListCtrl
 
@@ -522,7 +522,7 @@ def example(props):
     <img src="https://github.com/chriskiehl/re-wx-images/raw/images/wx_components/listctrl.PNG">
 </p>
 
-The `ListCtrl` in WX, while extremely powerful, has a super awkward and fiddly API. To tame this, re-wx only exposes a subset of the `ListCtrl`'s functionality and wraps it all up in a more declarative, straight forward API geared towards showing tables of information. However, if you need the full, unadultered power of `ListCtrl`, you can always use a `Ref` to grab a handle to the concrete wx instance. 
+The `ListCtrl` in WX, while extremely powerful, has a super awkward and fiddly API. To tame this, re-wx only exposes a subset of the `ListCtrl`'s functionality and wraps it all up in a more declarative, straight forward API geared towards showing tables of information. However, if you need the full, unadultered power of `ListCtrl`, you can always use a `Ref` to grab a handle to the concrete wx instance.
 
 
 **Example:**
@@ -557,13 +557,13 @@ def listctrl_example(props):
 
 **Understanding the `column_defs` and `data` props**
 
-`data` is a list of any arbirary type. It could be a list of lists, list of maps, or any `List[A]`.  
+`data` is a list of any arbirary type. It could be a list of lists, list of maps, or any `List[A]`.
 
-`column_defs` is how you define (a) what the columns of your table are, and (b) how the individual items in that column gets formatted. It's expressed as a list of maps, where each item in the list represents a column in your table. The `title` is used as the Column Header, and the `column` key should be a function (`A -> String`) which transforms an individual item from `data` into string form for display in the table. 
+`column_defs` is how you define (a) what the columns of your table are, and (b) how the individual items in that column gets formatted. It's expressed as a list of maps, where each item in the list represents a column in your table. The `title` is used as the Column Header, and the `column` key should be a function (`A -> String`) which transforms an individual item from `data` into string form for display in the table.
 
-**Availble Props:** 
+**Availble Props:**
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |column_defs| [{title, column}] | A list of column definitions specifying your column header and row fomatting functions |
 |data| List[A] | A list of data to be displayed in the table |
@@ -573,7 +573,7 @@ def listctrl_example(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
@@ -586,23 +586,23 @@ def listctrl_example(props):
 
 
 
-## Notebook 
+## Notebook
 
 <p align="center">
     <img src="https://github.com/chriskiehl/re-wx-images/raw/images/wx_components/notebook.png">
 </p>
 
-Notebooks are used for creating tabbed layouts. The `Notebook` is that parent container that holds all the tabs in the UI. You add pages by specifying `NotebookItem`s as children. 
- 
+Notebooks are used for creating tabbed layouts. The `Notebook` is that parent container that holds all the tabs in the UI. You add pages by specifying `NotebookItem`s as children.
+
 **Example:**
 
 ```python
-from rewx import wsx 
+from rewx import wsx
 from rewx.components import Notebook, NotebookItem, StaticText
 
 def example(props):
     return wsx(
-      [Notebook, {'on_change': props['handle_selection']},    
+      [Notebook, {'on_change': props['handle_selection']},
        [NotebookItem, {'title': 'Page 1', 'selected': props['activeSelection'] == 0},
         [StaticText, {'label': "Hello!"}]],
        [NotebookItem, {'title': 'Page 2!!!', 'selected': props['activeSelection'] == 1},
@@ -612,7 +612,7 @@ def example(props):
 
 **Availble Props:**
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |on_change| Callable[[CommandEvent], None] | A command event containing the selected index |
 |style| int | The style of the Notebook |
@@ -624,24 +624,24 @@ def example(props):
 <br />
 
 
-## NotebookItem 
+## NotebookItem
 
 <p align="center">
     <img src="https://github.com/chriskiehl/re-wx-images/raw/images/wx_components/notebook.png">
 </p>
 
-`NotebookItem`s are just opaque containers that hold any component you supply. They can _only_ be used with `Notebook` and must be direct children. This let's rewx register all of your components as pages in the Notebook behind the scenes. 
+`NotebookItem`s are just opaque containers that hold any component you supply. They can _only_ be used with `Notebook` and must be direct children. This let's rewx register all of your components as pages in the Notebook behind the scenes.
 
 
 **Example:**
 
 ```python
-from rewx import wsx 
+from rewx import wsx
 from rewx.components import Notebook, NotebookItem, StaticText
 
 def example(props):
     return wsx(
-      [Notebook, {'on_change': props['handle_selection']},    
+      [Notebook, {'on_change': props['handle_selection']},
        [NotebookItem, {'title': 'Page 1', 'selected': props['activeSelection'] == 0},
         [StaticText, {'label': "Hello!"}]],
        [NotebookItem, {'title': 'Page 2!!!', 'selected': props['activeSelection'] == 1},
@@ -651,7 +651,7 @@ def example(props):
 
 **Availble Props:**
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |selected | bool | A boolean controlling whether or not this tab is selected |
 |title | str| The title of the tab|
@@ -659,14 +659,14 @@ def example(props):
 
 
 
-<br /> 
+<br />
 
 ## Panel
 
 
-A plain WX.Panel. For a version with an attached Sizer, checkout [Block](#Block). 
+A plain WX.Panel. For a version with an attached Sizer, checkout [Block](#Block).
 
-Panel takes a backseat in re-wx to other types which have baked in Sizers and children management. In re-wx, panel is commonly used just as a spacer element when fine tuning layouts.  
+Panel takes a backseat in re-wx to other types which have baked in Sizers and children management. In re-wx, panel is commonly used just as a spacer element when fine tuning layouts.
 
 **Example:**
 
@@ -674,16 +674,16 @@ Panel takes a backseat in re-wx to other types which have baked in Sizers and ch
 def panel_as_spacer(props):
     return wsx(
       [Block, {'orient': wx.HORIZONTAL},
-        # proportion 1 means grow to consume all of the available space 
-        # because this is in a Horizontal Block, it'll have the effect 
-        # of right aligning our button 
-        [Panel, {'proportion': 1}] 
+        # proportion 1 means grow to consume all of the available space
+        # because this is in a Horizontal Block, it'll have the effect
+        # of right aligning our button
+        [Panel, {'proportion': 1}]
         [Button, {'label': 'A am right aligned thanks to the Panel'}]]
     )
 ```
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
@@ -691,14 +691,14 @@ def panel_as_spacer(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
@@ -708,7 +708,7 @@ def panel_as_spacer(props):
 
 
 
-<br /> 
+<br />
 
 ## RadioBox
 
@@ -734,10 +734,10 @@ def example(props):
 ```
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
-| selected | int | the index of the selected option | 
-| choices | [str] | A list of string to be displayed as options | 
+| selected | int | the index of the selected option |
+| choices | [str] | A list of string to be displayed as options |
 |on_change | callable | This function is called when the user interacts with the radiobox|
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
@@ -745,7 +745,7 @@ def example(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
@@ -758,7 +758,7 @@ def example(props):
 
 
 
-<br /> 
+<br />
 
 ## RadioButton
 
@@ -766,7 +766,7 @@ def example(props):
     <img src="https://github.com/chriskiehl/re-wx-images/raw/images/wx_components/radio-button.PNG">
 </p>
 
-An individual RadioButton. This should be used over [RadioBox ](#RadioBox) when you need fine-grained control over interactions and layout. 
+An individual RadioButton. This should be used over [RadioBox ](#RadioBox) when you need fine-grained control over interactions and layout.
 
 **Example:**
 
@@ -783,9 +783,9 @@ def example(props):
 ```
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
-| selected | int | the index of the selected option | 
+| selected | int | the index of the selected option |
 |on_change | callable | This function is called when the user interacts with the radiobox|
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
@@ -793,7 +793,7 @@ def example(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
@@ -806,7 +806,7 @@ def example(props):
 
 
 
-<br /> 
+<br />
 
 ## Slider
 
@@ -820,40 +820,40 @@ def example(props):
 ```
 def example(props):
     return wsx(
-      [Slider, {'value': 22, 
+      [Slider, {'value': 22,
                 'min': 0,
                 'max': 100}],
     )
 ```
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
-|value| int | Current value/position of the slider | 
-|min | int | Minimum value available in the slider | 
-|max | int | Maximum value available in the slider | 
-|on_change| callable | This function is called when the slider changes position | 
+|value| int | Current value/position of the slider |
+|min | int | Minimum value available in the slider |
+|max | int | Maximum value available in the slider |
+|on_change| callable | This function is called when the slider changes position |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |font| wx.Font | Sets the Font used by this component and all of its children|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
 
 
 
-<br /> 
+<br />
 
 ## SpinCtrl
 
@@ -867,32 +867,32 @@ def example(props):
 ```
 def example(props):
     return wsx(
-      [SpinCtrl, {'value': 22, 
+      [SpinCtrl, {'value': 22,
                 'min': 0,
                 'max': 100}],
     )
 ```
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
-|value| int | Current value of the spin control | 
-|min | int | Minimum value of the spin control | 
-|max | int | Maximum value of the spin control | 
+|value| int | Current value of the spin control |
+|min | int | Minimum value of the spin control |
+|max | int | Maximum value of the spin control |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |font| wx.Font | Sets the Font used by this component and all of its children|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
@@ -900,7 +900,7 @@ def example(props):
 
 
 
-<br /> 
+<br />
 
 ## SpinCtrlDouble
 
@@ -914,7 +914,7 @@ def example(props):
 ```
 def example(props):
     return wsx(
-      [SpinCtrlDouble, {'value': 22, 
+      [SpinCtrlDouble, {'value': 22,
                 'min': 0,
                 'max': 100,
                 'digits': 20,
@@ -923,27 +923,27 @@ def example(props):
 ```
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
-|value| float | Current value of the spin control | 
-|min | float | Minimum value of the spin control | 
-|max | float | Maximum value of the spin control | 
+|value| float | Current value of the spin control |
+|min | float | Minimum value of the spin control |
+|max | float | Maximum value of the spin control |
 |digits | int | Sets the maximum precision of the spin control|
-|increment | float | Sets the increment amount used by the spin control | 
+|increment | float | Sets the increment amount used by the spin control |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |font| wx.Font | Sets the Font used by this component and all of its children|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
@@ -966,7 +966,7 @@ def example(props):
 </p>
 
 
-Display a fixed image. 
+Display a fixed image.
 
 **Example:**
 
@@ -978,7 +978,7 @@ def button_example(props):
 **Availble Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |uri| string | filepath to the image you want displayed. re-wx will handle loading it and turning it into a bitmap |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
@@ -986,13 +986,13 @@ def button_example(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
@@ -1017,7 +1017,7 @@ def button_example(props):
 </p>
 
 
-Wraps its children in a bordered box with a name. 
+Wraps its children in a bordered box with a name.
 
 **Example:**
 
@@ -1037,21 +1037,21 @@ def example(props):
 **Availble Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
-|label | str | Text to display at the top of the box | 
+|label | str | Text to display at the top of the box |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
@@ -1071,9 +1071,9 @@ def example(props):
 
 ## StaticLine
 
-Displays a Horizontal or Vertical line. 
+Displays a Horizontal or Vertical line.
 
-> Usage Note: make sure to set appropriate `proportion` and `flag` props to ensure that the line actually grows to fill the space you expect. If you're not seeing any lines when using this control, most of the time it's because your sizer isn't configured appropriately. Protip: Use the wx.Inspect tool! 
+> Usage Note: make sure to set appropriate `proportion` and `flag` props to ensure that the line actually grows to fill the space you expect. If you're not seeing any lines when using this control, most of the time it's because your sizer isn't configured appropriately. Protip: Use the wx.Inspect tool!
 
 **Example:**
 
@@ -1088,21 +1088,21 @@ def example(props):
 **Availble Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
-|style | str | [Style flags](https://docs.wxpython.org/wx.StaticLine.html#styles-window-styles) | 
+|style | str | [Style flags](https://docs.wxpython.org/wx.StaticLine.html#styles-window-styles) |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
@@ -1127,7 +1127,7 @@ def example(props):
 </p>
 
 
-A basic text element. This is the main way to display strings in a WX application. 
+A basic text element. This is the main way to display strings in a WX application.
 
 **Example:**
 
@@ -1140,22 +1140,22 @@ def example(props):
 **Availble Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |Label | str | The text to be displayed|
-|style | int | [See the WXPython docs for style options](https://www.wxpython.org/Phoenix/docs/html/wx.StaticText.html)| 
+|style | int | [See the WXPython docs for style options](https://www.wxpython.org/Phoenix/docs/html/wx.StaticText.html)|
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
@@ -1184,25 +1184,25 @@ def example(props):
 **Availble Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |value | str | The current text value of the control |
 |placeholder| string | The hint text to display when the control is empty|
 |editable| boolean | When false makes the control readonly|
 |on_change| callable | This function will be called when the user enters text|
-|style | int | [See the WXPython docs for style options](https://www.wxpython.org/Phoenix/docs/html/wx.TextCtrl.html)| 
+|style | int | [See the WXPython docs for style options](https://www.wxpython.org/Phoenix/docs/html/wx.TextCtrl.html)|
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
@@ -1221,7 +1221,7 @@ def example(props):
 </p>
 
 
-This is an alias for TextCtrl, but with its `style` prop pre-baked with `wx.TE_MULTILINE`. 
+This is an alias for TextCtrl, but with its `style` prop pre-baked with `wx.TE_MULTILINE`.
 
 
 **Example:**
@@ -1235,25 +1235,25 @@ def example(props):
 **Availble Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |value | str | The current text value of the control |
 |placeholder| string | The hint text to display when the control is empty|
 |editable| boolean | When false makes the control readonly|
 |on_change| callable | This function will be called when the user enters text|
-|style | int | [See the WXPython docs for style options](https://www.wxpython.org/Phoenix/docs/html/wx.TextCtrl.html)| 
+|style | int | [See the WXPython docs for style options](https://www.wxpython.org/Phoenix/docs/html/wx.TextCtrl.html)|
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |foreground_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |
 
 
 
@@ -1266,7 +1266,7 @@ def example(props):
 
 <br/>
 
-## ToggleButton 
+## ToggleButton
 
 
 <p align="center">
@@ -1274,7 +1274,7 @@ def example(props):
 </p>
 
 
-Your basic button. 
+Your basic button.
 
 **Example:**
 
@@ -1286,7 +1286,7 @@ def button_example(props):
 **Availble Props:**
 
 
-| key | Type | Description | 
+| key | Type | Description |
 |------|------|---------|
 |label| string | The label displayed on the button |
 |background_color| rgb value | Either an rgb tuple (e.g. `(255, 255, 255)` or a hex string (e.g. `"#ff00ff"`)|
@@ -1295,11 +1295,11 @@ def button_example(props):
 |name| str | Adds the supplied name to the generated wx instance. This'll show in wx.Inspector and makes debugging much easier |
 |min_size| (int, int) | A tuple of (min_width, min_height). Use -1 to let WX auto-size the component.|
 |max_size| (int, int) | A tuple of (max_width, max_height). Use -1 to let WX auto-size the component.|
-|tooltip| str | Displays a string when the user hovers over the component | 
+|tooltip| str | Displays a string when the user hovers over the component |
 |show| boolean | Toggle whether this item is visible or not. |
 |enabled| boolean | Enables/Disables the component. |
 |style| any | style is context dependent |
 |proportion | int |  This parameter controls how much space this element will take up along the main axis of its parent sizer. 0 means don't grow at all, values > 0 cause it to scale proportionally relative to items with the same parent. See the [wx.Sizer docs for more info](https://www.wxpython.org/Phoenix/docs/html/sizers_overview.html#sizers-overview) |
 |flag | int | An ORd combination of flags which control the Sizer's behavior  (e.g. `{'flag': wx.LEFT \| wx.RIGHT}`)|
 |border | int | Sets the amount of border/padding which should be applied to the options specified in `flag` |
-|on_click | callable | Calls the supplied function when this element is click. | 
+|on_click | callable | Calls the supplied function when this element is click. |

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -123,6 +123,15 @@ class FilePickerCtrlSave(wx.FilePickerCtrl):
 class DirPickerCtrl(wx.DirPickerCtrl):
     """
     Wrapper for a `DirPickerCtrl` with a `FileDropTarget`.
+
+    Extra Props
+    ```
+    {
+      text_font: wx.Font,
+      on_change: (event:FileDirPickerEvent),
+      on_dropdir: (x:int, y:int, path:str),
+    }
+    ```
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -32,7 +32,6 @@ SpinCtrl = wx.SpinCtrl
 SpinCtrlDouble = wx.SpinCtrlDouble
 StaticBitmap = wx.StaticBitmap
 StaticBox = wx.StaticBox
-StaticBoxSizer = wx.StaticBoxSizer
 StaticLine = wx.StaticLine
 StaticText = wx.StaticText
 TextCtrl = wx.TextCtrl

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -17,9 +17,8 @@ CalendarCtrl = wx.adv.CalendarCtrl
 CheckBox = wx.CheckBox
 # CollapsiblePane = wx.CollapsiblePane
 ComboBox = wx.ComboBox
-Dropdown = ComboBox
 DirPickerCtrl = wx.DirPickerCtrl
-FilePickerCtrl = wx.FilePickerCtrl
+Dropdown = ComboBox
 Frame = wx.Frame
 Gauge = wx.Gauge
 ListBox = wx.ListBox
@@ -33,6 +32,7 @@ SpinCtrl = wx.SpinCtrl
 SpinCtrlDouble = wx.SpinCtrlDouble
 StaticBitmap = wx.StaticBitmap
 StaticBox = wx.StaticBox
+StaticBoxSizer = wx.StaticBoxSizer
 StaticLine = wx.StaticLine
 StaticText = wx.StaticText
 TextCtrl = wx.TextCtrl
@@ -89,4 +89,20 @@ class NotebookItem(wx.Panel):
       [NotebookItem, {'active': False}
         [AnyComponent, {...}]]]
     ```
+    """
+
+class FilePickerCtrlOpen(wx.FilePickerCtrl):
+    """
+    Wrapper for a FilePickerCtrl with default style
+    `wx.FLP_OPEN | wx.FLP_FILE_MUST_EXIST`
+
+    https://docs.wxpython.org/wx.FilePickerCtrl.html
+    """
+
+class FilePickerCtrlSave(wx.FilePickerCtrl):
+    """
+    Wrapper for a FilePickerCtrl with style
+    `wx.FLP_SAVE`
+
+    https://docs.wxpython.org/wx.FilePickerCtrl.html
     """

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -106,6 +106,9 @@ class FilePickerCtrlOpen(wx.FilePickerCtrl):
 
     https://docs.wxpython.org/wx.FilePickerCtrl.html
     """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.self_managed = True # creates and destroys its own children
 
 class FilePickerCtrlSave(wx.FilePickerCtrl):
     """
@@ -114,3 +117,6 @@ class FilePickerCtrlSave(wx.FilePickerCtrl):
 
     https://docs.wxpython.org/wx.FilePickerCtrl.html
     """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.self_managed = True # creates and destroys its own children

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -49,6 +49,15 @@ class Grid(wx.Panel):
     """
     pass
 
+class FlexGrid(wx.Panel):
+    """
+    Wrapper type for creating a Panel
+    with a FlexGridSizer
+
+    https://wxpython.org/Phoenix/docs/html/wx.FlexGridSizer.html
+    """
+    pass
+
 class Block(wx.Panel):
     """
     Wrapper type for creating a panel

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -26,7 +26,6 @@ ListCtrl = wx.ListCtrl
 Panel = wx.Panel
 RadioBox = wx.RadioBox
 RadioButton = wx.RadioButton
-ScrolledPanel = wx.lib.scrolledpanel.ScrolledPanel
 Slider = wx.Slider
 SpinCtrl = wx.SpinCtrl
 SpinCtrlDouble = wx.SpinCtrlDouble
@@ -120,3 +119,14 @@ class FilePickerCtrlSave(wx.FilePickerCtrl):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.self_managed = True # creates and destroys its own children
+
+class ScrolledPanel(wx.lib.scrolledpanel.ScrolledPanel):
+    """
+    Wrapper for a ScrolledPanel which doesn't jump the scroll on focus.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    # https://discuss.wxpython.org/t/prevent-scrolledpanel-scrolling-to-a-widget-that-has-focus/27257
+    def OnChildFocus(self, event):
+        pass

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -18,6 +18,7 @@ CheckBox = wx.CheckBox
 # CollapsiblePane = wx.CollapsiblePane
 ComboBox = wx.ComboBox
 Dropdown = ComboBox
+FilePickerCtrl = wx.FilePickerCtrl
 Frame = wx.Frame
 Gauge = wx.Gauge
 ListBox = wx.ListBox

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -135,7 +135,7 @@ class DirPickerCtrl(wx.DirPickerCtrl):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.self_managed = True # creates and destroys its own children
-    
+
     def _on_change_impl(self, event:wx.FileDirPickerEvent):
         if hasattr(self, '_on_change'):
             self._on_change(event.GetPath())

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -122,20 +122,24 @@ class FilePickerCtrlSave(wx.FilePickerCtrl):
 
 class DirPickerCtrl(wx.DirPickerCtrl):
     """
-    Wrapper for a `DirPickerCtrl` with a `FileDropTarget`.
+    Wrapper for a `DirPickerCtrl` (with a `FileDropTarget` for MS Windows).
 
     Extra Props
     ```
     {
       text_font: wx.Font,
-      on_change: (event:FileDirPickerEvent),
-      on_dropdir: (x:int, y:int, path:str),
+      on_change: (path:str):None
     }
     ```
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.self_managed = True # creates and destroys its own children
+    
+    def _on_change_impl(self, event:wx.FileDirPickerEvent):
+        if hasattr(self, '_on_change'):
+            self._on_change(event.GetPath())
+
 
 class ScrolledPanel(wx.lib.scrolledpanel.ScrolledPanel):
     """

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -18,6 +18,7 @@ CheckBox = wx.CheckBox
 # CollapsiblePane = wx.CollapsiblePane
 ComboBox = wx.ComboBox
 Dropdown = ComboBox
+DirPickerCtrl = wx.DirPickerCtrl
 FilePickerCtrl = wx.FilePickerCtrl
 Frame = wx.Frame
 Gauge = wx.Gauge

--- a/rewx/components.py
+++ b/rewx/components.py
@@ -111,7 +111,7 @@ class FilePickerCtrlOpen(wx.FilePickerCtrl):
 
 class FilePickerCtrlSave(wx.FilePickerCtrl):
     """
-    Wrapper for a FilePickerCtrl with style
+    Wrapper for a `FilePickerCtrl` with style
     `wx.FLP_SAVE`
 
     https://docs.wxpython.org/wx.FilePickerCtrl.html
@@ -120,9 +120,17 @@ class FilePickerCtrlSave(wx.FilePickerCtrl):
         super().__init__(*args, **kwargs)
         self.self_managed = True # creates and destroys its own children
 
+class DirPickerCtrl(wx.DirPickerCtrl):
+    """
+    Wrapper for a `DirPickerCtrl` with a `FileDropTarget`.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.self_managed = True # creates and destroys its own children
+
 class ScrolledPanel(wx.lib.scrolledpanel.ScrolledPanel):
     """
-    Wrapper for a ScrolledPanel which doesn't jump the scroll on focus.
+    Wrapper for a `ScrolledPanel` which doesn't jump the scroll on focus.
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/rewx/core.py
+++ b/rewx/core.py
@@ -198,14 +198,12 @@ def patch(dom: wx.Window, vdom) -> wx.Window:
                     # declared component tree
                     if not isinstance(orphan, wx.lib.inspection.InspectionFrame):
                         orphan.Destroy()
+                # https://docs.wxpython.org/wx.Window.html#wx.Window.Layout
+                dom.Layout()
 
             newdom = dom
         else:
             raise Exception("unexpected case!")
-        p = parent
-        while p:
-            p.Layout()
-            p = p.GetParent()
         return newdom
     finally:
         # TODO: we sometimes call parent.Thaw() when

--- a/rewx/core.py
+++ b/rewx/core.py
@@ -97,15 +97,8 @@ def patch(dom: wx.Window, vdom):
             newdom = dom
         elif isinstance(dom, vdom['type']):
             update(vdom, dom)
-            # print("VDOM")
-            # print(vdom)
-            # print ("DOM")
-            # print(dom)
             pool = {f'__index_{index}': child for index, child in enumerate(dom.GetChildren())}
             for index, child in enumerate(vdom['props'].get('children', [])):
-                # print("Child")
-                # print(str(child.__class__) + ": " + str(child.__dict__))
-                # print(child)
                 key = f'__index_{index}'
                 if key in pool:
                     patch(pool[key], child)

--- a/rewx/core.py
+++ b/rewx/core.py
@@ -129,21 +129,17 @@ def patch(dom: wx.Window, vdom):
                             child['props'].get('flag', 0),
                             child['props'].get('border', 0)
                         )
-            # # any keys which haven't been removed in the
-            # # above loop represent wx.Objects which are no longer
-            # # part of the virtualdom and should thus be removed.
-            # for key, orphan in pool.items():
-            #     # Debugging InspectionFrame gets lumped in with the
-            #     # top-level hierarchy. We want to leave this alone as
-            #     # it's there for debugging and not part of the actual
-            #     # declared component tree
-            #     print(str(orphan.__class__) + ": " + str(orphan.__dict__))
-            #     if not isinstance(orphan, wx.lib.inspection.InspectionFrame):
-            #         dom.RemoveChild(orphan)
-            #         print("Destroy")
-            #         # print(orphan)
-            #         print(str(orphan.__class__) + ": " + str(orphan.__dict__))
-            #         orphan.Destroy()
+            # any keys which haven't been removed in the
+            # above loop represent wx.Objects which are no longer
+            # part of the virtualdom and should thus be removed.
+            for key, orphan in pool.items():
+                # Debugging InspectionFrame gets lumped in with the
+                # top-level hierarchy. We want to leave this alone as
+                # it's there for debugging and not part of the actual
+                # declared component tree
+                if not isinstance(orphan, wx.lib.inspection.InspectionFrame):
+                    dom.RemoveChild(orphan)
+                    orphan.Destroy()
 
             newdom = dom
         else:

--- a/rewx/core.py
+++ b/rewx/core.py
@@ -5,6 +5,7 @@ import functools
 from threading import Lock
 
 import wx
+import wx.lib.inspection # Needed for the orphan remover
 from inspect import isclass
 
 from rewx.dispatch import mount, update

--- a/rewx/core.py
+++ b/rewx/core.py
@@ -19,7 +19,9 @@ update.merge_registries(_update._registry)
 
 def wsx(f):
     def convert(spec: list):
-        type, props, *children = spec
+        type = spec[0]
+        props = spec[1]
+        children = spec[2:]
         return create_element(type, props, children=list(map(convert, children)))
     # being used as a decorator
     if callable(f):

--- a/rewx/core.py
+++ b/rewx/core.py
@@ -97,8 +97,15 @@ def patch(dom: wx.Window, vdom):
             newdom = dom
         elif isinstance(dom, vdom['type']):
             update(vdom, dom)
+            # print("VDOM")
+            # print(vdom)
+            # print ("DOM")
+            # print(dom)
             pool = {f'__index_{index}': child for index, child in enumerate(dom.GetChildren())}
             for index, child in enumerate(vdom['props'].get('children', [])):
+                # print("Child")
+                # print(str(child.__class__) + ": " + str(child.__dict__))
+                # print(child)
                 key = f'__index_{index}'
                 if key in pool:
                     patch(pool[key], child)
@@ -122,17 +129,21 @@ def patch(dom: wx.Window, vdom):
                             child['props'].get('flag', 0),
                             child['props'].get('border', 0)
                         )
-            # any keys which haven't been removed in the
-            # above loop represent wx.Objects which are no longer
-            # part of the virtualdom and should thus be removed.
-            for key, orphan in pool.items():
-                # Debugging InspectionFrame gets lumped in with the
-                # top-level hierarchy. We want to leave this alone as
-                # it's there for debugging and not part of the actual
-                # declared component tree
-                if not isinstance(orphan, wx.lib.inspection.InspectionFrame):
-                    dom.RemoveChild(orphan)
-                    orphan.Destroy()
+            # # any keys which haven't been removed in the
+            # # above loop represent wx.Objects which are no longer
+            # # part of the virtualdom and should thus be removed.
+            # for key, orphan in pool.items():
+            #     # Debugging InspectionFrame gets lumped in with the
+            #     # top-level hierarchy. We want to leave this alone as
+            #     # it's there for debugging and not part of the actual
+            #     # declared component tree
+            #     print(str(orphan.__class__) + ": " + str(orphan.__dict__))
+            #     if not isinstance(orphan, wx.lib.inspection.InspectionFrame):
+            #         dom.RemoveChild(orphan)
+            #         print("Destroy")
+            #         # print(orphan)
+            #         print(str(orphan.__class__) + ": " + str(orphan.__dict__))
+            #         orphan.Destroy()
 
             newdom = dom
         else:
@@ -251,8 +262,8 @@ def render(element, parent):
     else:
         # TODO: rest of this message
         raise TypeError(f'''
-            An unknown type ("{element['type']}") was supplied as a renderable 
-            element. 
+            An unknown type ("{element['type']}") was supplied as a renderable
+            element.
         ''')
 
 class Ref:

--- a/rewx/core.py
+++ b/rewx/core.py
@@ -163,7 +163,6 @@ def patch(dom: wx.Window, vdom) -> wx.Window:
                         # Maybe patch returns a different domchild, possibly a different type of domchild.
                         newdomchild = patch(domchild, child)
                         if newdomchild is not domchild:
-                            childrenbefore = sizer.GetItemCount()
                             # Only a Sizer can Insert() at a position.
                             domchild.Destroy()
                             sizer.Insert(
@@ -173,7 +172,6 @@ def patch(dom: wx.Window, vdom) -> wx.Window:
                                 child['props'].get('flag', 0),
                                 child['props'].get('border', 0)
                             )
-                            childrenafter = sizer.GetItemCount()
                             # We can't use
                             # https://docs.wxpython.org/wx.Sizer.html#wx.Sizer.Replace
                             # because it doesn't allow us to set proportion, flag, border.

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -2,6 +2,7 @@
 This module contains all of the mount/update
 functions for re-wx's supported widget types.
 """
+from operator import attrgetter
 import wx
 import wx.adv
 import wx.media
@@ -73,11 +74,10 @@ def set_basic_props(instance, props):
     for key, val in props.items():
         if key.startswith('on_'):
             continue
-        try:
-            getattr(instance, available_controls[key])(val)
-        except KeyError:
-            # prop which doesn't apply to this control
-            pass
+        if key in available_controls:
+            setter_name = available_controls[key]
+            if hasattr(instance, setter_name):
+                getattr(instance, setter_name)(val)
     return instance
 
 
@@ -286,6 +286,8 @@ def combobox(element, instance: wx.ComboBox) -> wx.Object:
 
 @mount.register(wx.DirPickerCtrl)
 def dir_picker_ctrl(element, parent):
+    # TODO make this a drop target
+    # https://www.blog.pythonlibrary.org/2012/06/20/wxpython-introduction-to-drag-and-drop/
     instance = wx.DirPickerCtrl(parent)
     instance.self_managed = True # DirPickerCtrl has a self-managed Button child.
     return update(element, instance)

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -150,6 +150,8 @@ def button(element, instance: wx.Button):
     #     # spawned while it was disable to the now recently enabled
     #     # button. This behavior doesn't happen if we navigate away
     #     instance.Navigate()
+    if 'label_markup' in props:
+        instance.SetLabelMarkup(props['label_markup'])
     instance.Unbind(wx.EVT_BUTTON)
     if props.get('on_click'):
         instance.Bind(wx.EVT_BUTTON, props['on_click'])

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -271,6 +271,25 @@ def combobox(element, instance: wx.ComboBox) -> wx.Object:
 
     return instance
 
+@mount.register(wx.DirPickerCtrl)
+def file_picker_ctrl(element, parent):
+    return update(element, wx.DirPickerCtrl(parent))
+
+@update.register(wx.DirPickerCtrl)
+def file_picker_ctrl(element, instance: wx.DirPickerCtrl):
+    props = element['props']
+    set_basic_props(instance, props)
+    additions = {
+        'path': 'SetPath'
+    }
+    for prop_key, wx_method in additions.items():
+        if prop_key in props:
+            getattr(instance, wx_method)(props[prop_key])
+    instance.Unbind(wx.EVT_DIRPICKER_CHANGED)
+    if props.get('on_change'):
+        instance.Bind(wx.EVT_DIRPICKER_CHANGED, props['on_change'])
+    return instance
+
 @mount.register(wx.FilePickerCtrl)
 def file_picker_ctrl(element, parent):
     return update(element, wx.FilePickerCtrl(parent))

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -290,12 +290,18 @@ class DirPickerDropTarget(wx.FileDropTarget):
     """
     We are required to inherit from wx.FileDropTarget
     """
-    def __init__(self, on_dropfile, *args, **kwargs):
+    def __init__(self, on_dropdir, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.on_dropfile = on_dropfile
+        self.on_dropdir = on_dropdir
     def OnDropFiles(self, x:int, y:int, filenames:list[str]):
-        self.on_dropfile(x,y,filenames)
-        return True
+        if len(filenames) == 1:
+            path = filenames[0]
+            if os.path.isdir(path):
+                self.on_dropdir(x,y,path)
+                return True # wx.DragCopy?
+        return False # wx.DragNone?
+    def OnDragOver(self, x:int, y:int, defResult):
+        return wx.DragCopy
 
 @mount.register(DirPickerCtrl)
 def dir_picker_ctrl(element, parent):
@@ -319,8 +325,8 @@ def dir_picker_ctrl(element, instance: DirPickerCtrl):
     instance.Unbind(wx.EVT_DIRPICKER_CHANGED)
     if 'on_change' in props:
         instance.Bind(wx.EVT_DIRPICKER_CHANGED, props['on_change'])
-    if 'on_dropfile' in props:
-        droptarget = DirPickerDropTarget(props['on_dropfile'])
+    if 'on_dropdir' in props:
+        droptarget = DirPickerDropTarget(props['on_dropdir'])
         # https://docs.wxpython.org/wx.FileDropTarget.html
         instance.SetDropTarget(droptarget)
     return instance

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -541,18 +541,6 @@ def staticbox(element, instance: wx.StaticBox):
 
     return instance
 
-@mount.register(wx.StaticBoxSizer)
-def staticboxsizer(element, parent):
-    instance = wx.StaticBoxSizer(element['props'].get('orient', wx.VERTICAL), parent)
-    return update(element, instance)
-
-@update.register(wx.StaticBoxSizer)
-def staticboxsizer(element, instance: wx.StaticBoxSizer):
-    props = element['props']
-    set_basic_props(instance, props)
-    return instance
-
-
 @mount.register(wx.Slider)
 def slider(element, parent):
     return update(element, wx.Slider(parent))

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -933,6 +933,12 @@ def textctrl(element, instance: wx.TextCtrl):
     instance.Unbind(wx.EVT_TEXT)
     if 'on_change' in props:
         instance.Bind(wx.EVT_TEXT, props['on_change'])
+    instance.Unbind(wx.EVT_SET_FOCUS)
+    if 'on_focus_set' in props:
+        instance.Bind(wx.EVT_SET_FOCUS, props['on_focus_set'])
+    instance.Unbind(wx.EVT_KILL_FOCUS)
+    if 'on_focus_kill' in props:
+        instance.Bind(wx.EVT_KILL_FOCUS, props['on_focus_kill'])
     return instance
 
 

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -63,6 +63,7 @@ exclusions = {
     FlexGrid: {'value', 'label', 'style'},
     wx.StaticBitmap: {'value'},
     wx.ToggleButton: {'value'},
+    wx.ComboBox: {'style'},
 }
 
 
@@ -248,7 +249,11 @@ def collapsiblepanel(element, instance: wx.CollapsiblePane):
 
 @mount.register(wx.ComboBox)
 def combobox(element, parent):
-    return update(element, wx.ComboBox(parent, choices=element['props'].get('choices', [])))
+    props = element['props']
+    return update(
+        element,
+        wx.ComboBox(parent, choices=props.get('choices', []), style=props.get('style', 0))
+        )
 
 @update.register(wx.ComboBox)
 def combobox(element, instance: wx.ComboBox) -> wx.Object:
@@ -267,7 +272,7 @@ def combobox(element, instance: wx.ComboBox) -> wx.Object:
     for _ in instance.GetItems():
         instance.Delete(0)
     instance.AppendItems(props.get('choices', []))
-    if 'value' in props:
+    if 'value' in element['props']:
         instance.SetSelection(props['choices'].index(element['props'].get('value')))
 
     if props.get('on_change'):

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -776,6 +776,12 @@ def scrolledpanel(element, parent):
     panel = update(element, ScrolledPanel(parent))
     sizer = wx.BoxSizer(element['props'].get('orient', wx.VERTICAL))
     panel.SetSizer(sizer)
+    panel.last_scroll_pos = None
+    def handle_scroll(event):
+        # Save the scroll position so that it can be restored after update
+        panel.last_scroll_pos = panel.GetViewStart()
+        event.Skip() # Propagate this event
+    panel.Bind(wx.EVT_SCROLLWIN, handle_scroll)
     return panel
 
 @update.register(ScrolledPanel)
@@ -786,6 +792,10 @@ def scrolledpanel(element, instance: ScrolledPanel):
         scroll_x=props.get('scroll_x', False),
         scroll_y=props.get('scroll_y', False)
     )
+    # Restore the scroll position from before the update
+    if hasattr(instance, 'last_scroll_pos'):
+        if instance.last_scroll_pos:
+            wx.CallAfter(instance.Scroll, instance.last_scroll_pos)
     instance.Unbind(wx.EVT_LEFT_DOWN)
     if 'on_click' in props:
         instance.Bind(wx.EVT_LEFT_DOWN, props['on_click'])

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -61,6 +61,8 @@ exclusions = {
     FilePickerCtrlOpen: {'value', 'style'},
     FilePickerCtrlSave: {'value', 'style'},
     FlexGrid: {'value', 'label', 'style'},
+    wx.StaticBitmap: {'value'},
+    wx.ToggleButton: {'value'},
 }
 
 

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -271,6 +271,24 @@ def combobox(element, instance: wx.ComboBox) -> wx.Object:
 
     return instance
 
+@mount.register(wx.FilePickerCtrl)
+def file_picker_ctrl(element, parent):
+    return update(element, wx.FilePickerCtrl(parent))
+
+@update.register(wx.FilePickerCtrl)
+def file_picker_ctrl(element, instance: wx.FilePickerCtrl):
+    props = element['props']
+    set_basic_props(instance, props)
+    additions = {
+        'path': 'SetPath'
+    }
+    for prop_key, wx_method in additions.items():
+        if prop_key in props:
+            getattr(instance, wx_method)(props[prop_key])
+    instance.Unbind(wx.EVT_FILEPICKER_CHANGED)
+    if props.get('on_change'):
+        instance.Bind(wx.EVT_FILEPICKER_CHANGED, props['on_change'])
+    return instance
 
 @mount.register(wx.Gauge)
 def gauge(element, parent):

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -603,7 +603,9 @@ def spinctrl(element, instance: wx.SpinCtrl):
 
 @mount.register(wx.SpinCtrlDouble)
 def spinctrldouble(element, parent):
-    return update(element, wx.SpinCtrlDouble(parent))
+    instance = wx.SpinCtrlDouble(parent)
+    instance.self_managed = True # SpinCtrlDouble has a self-managed child.
+    return update(element, instance)
 
 @update.register(wx.SpinCtrlDouble)
 def spinctrldouble(element, instance: wx.SpinCtrlDouble):
@@ -614,9 +616,9 @@ def spinctrldouble(element, instance: wx.SpinCtrlDouble):
     instance.SetIncrement(props.get('increment', 0))
     if 'digits' in props:
         instance.SetDigits(props['digits'])
-    instance.Unbind(wx.EVT_SPINCTRL)
+    instance.Unbind(wx.EVT_SPINCTRLDOUBLE)
     if 'on_change' in props:
-        instance.Bind(wx.EVT_SPINCTRL, props['on_change'])
+        instance.Bind(wx.EVT_SPINCTRLDOUBLE, props['on_change'])
     return instance
 
 

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -616,7 +616,7 @@ def spinctrldouble(element, instance: wx.SpinCtrlDouble):
         instance.SetDigits(props['digits'])
     instance.Unbind(wx.EVT_SPINCTRL)
     if 'on_change' in props:
-        instance.Bind(wx.EVT_SLIDER, props['on_change'])
+        instance.Bind(wx.EVT_SPINCTRL, props['on_change'])
     return instance
 
 

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -14,7 +14,7 @@ from wx.lib.scrolledpanel import ScrolledPanel
 from rewx.dispatch import mount, update
 from wx.richtext import RichTextCtrl
 import sys
-from rewx.components import Block, Grid, TextArea, SVG, SVGButton, NotebookItem, FilePickerCtrlOpen, FilePickerCtrlSave
+from rewx.components import Block, Grid, FlexGrid, TextArea, SVG, SVGButton, NotebookItem, FilePickerCtrlOpen, FilePickerCtrlSave
 from rewx.util import exclude
 from rewx.bitmap_support import load, resize_image, to_bitmap
 from rewx.util import identity
@@ -57,9 +57,10 @@ exclusions = {
     SVG: {'value'},
     SVGButton: {'value'},
     ScrolledPanel: {'value'},
-    wx.DirPickerCtrl: {'style'},
-    FilePickerCtrlOpen: {'style'},
-    FilePickerCtrlSave: {'style'},
+    wx.DirPickerCtrl: {'value', 'style'},
+    FilePickerCtrlOpen: {'value', 'style'},
+    FilePickerCtrlSave: {'value', 'style'},
+    FlexGrid: {'value', 'label', 'style'},
 }
 
 
@@ -776,9 +777,26 @@ def grid(element, parent):
     panel.SetSizer(sizer)
     return update(element, panel)
 
-
 @update.register(Grid)
 def grid(element, instance: Grid):
+    props = element['props']
+    set_basic_props(instance, props)
+    instance.Unbind(wx.EVT_LEFT_DOWN)
+    if 'on_click' in props:
+        instance.Bind(wx.EVT_LEFT_DOWN, props['on_click'])
+    return instance
+
+
+@mount.register(FlexGrid)
+def flexgrid(element, parent):
+    props = element['props']
+    panel = FlexGrid(parent)
+    sizer = wx.FlexGridSizer(props.get('cols', 1), gap=props.get('gap', (0, 0)))
+    panel.SetSizer(sizer)
+    return update(element, panel)
+
+@update.register(FlexGrid)
+def flexgrid(element, instance: FlexGrid):
     props = element['props']
     set_basic_props(instance, props)
     instance.Unbind(wx.EVT_LEFT_DOWN)

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -591,7 +591,7 @@ def spinctrl(element, instance: wx.SpinCtrl):
     instance.SetMin(props.get('min', 0))
     instance.Unbind(wx.EVT_SPINCTRL)
     if 'on_change' in props:
-        instance.Bind(wx.EVT_SLIDER, props['on_change'])
+        instance.Bind(wx.EVT_SPINCTRL, props['on_change'])
     return instance
 
 
@@ -795,6 +795,7 @@ def scrolledpanel(element, instance: ScrolledPanel):
     # Restore the scroll position from before the update
     if hasattr(instance, 'last_scroll_pos'):
         if instance.last_scroll_pos:
+            # This works but it flickers because the widgets aren't frozen.
             wx.CallAfter(instance.Scroll, instance.last_scroll_pos)
     instance.Unbind(wx.EVT_LEFT_DOWN)
     if 'on_click' in props:

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -296,6 +296,10 @@ def dir_picker_ctrl(element, parent):
 def dir_picker_ctrl(element, instance: wx.DirPickerCtrl):
     props = element['props']
     set_basic_props(instance, props)
+    if instance.HasTextCtrl():
+        textctrl = instance.GetTextCtrl()
+        if 'text_font' in props:
+            textctrl.SetFont(props['text_font'])
     additions = {
         'path': 'SetPath'
     }

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -864,6 +864,7 @@ def staticbitmap(element, parent):
 @update.register(wx.StaticBitmap)
 def staticbitmap(element, instance: wx.StaticBitmap):
     props = element['props']
+    set_basic_props(instance, props)
     if props.get('uri'):
         # only load and update the image if it has changed.
         if instance._rewx_cache.get('uri', 'rewx::nothing') != props['uri']:

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -292,7 +292,7 @@ class DirPickerDropTarget(wx.FileDropTarget):
     """
     def __init__(self, dirPickerCtrl, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.dirPickerCtrl = dirPickerCtrl 
+        self.dirPickerCtrl = dirPickerCtrl
     def OnDropFiles(self, x:int, y:int, filenames:list[str]):
         if len(filenames) == 1:
             path = filenames[0]
@@ -361,6 +361,7 @@ def file_picker_ctrl_open(element, instance: FilePickerCtrlOpen):
 @mount.register(FilePickerCtrlSave)
 def file_picker_ctrl_save(element, parent):
     props = element['props']
+    # TODO This default wildcard prop value is wrong, it should be maybe FileSelectorDefaultWildcardStr?
     return update(element, FilePickerCtrlSave(parent, style=wx.FLP_SAVE, wildcard=props.get('wildcard', '*.*')))
 
 @update.register(FilePickerCtrlSave)

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -789,6 +789,9 @@ def scrolledpanel(element, instance: ScrolledPanel):
     instance.Unbind(wx.EVT_LEFT_DOWN)
     if 'on_click' in props:
         instance.Bind(wx.EVT_LEFT_DOWN, props['on_click'])
+    instance.Unbind(wx.EVT_SIZE)
+    if 'on_size' in props:
+        instance.Bind(wx.EVT_SIZE, props['on_size'])
     return instance
 
 

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -10,11 +10,10 @@ import wx.html2
 import wx.svg
 # TODO: warn on unknown props?
 import os
-from wx.lib.scrolledpanel import ScrolledPanel
 from rewx.dispatch import mount, update
 from wx.richtext import RichTextCtrl
 import sys
-from rewx.components import Block, Grid, FlexGrid, TextArea, SVG, SVGButton, NotebookItem, FilePickerCtrlOpen, FilePickerCtrlSave
+from rewx.components import Block, Grid, FlexGrid, TextArea, SVG, SVGButton, NotebookItem, FilePickerCtrlOpen, FilePickerCtrlSave, ScrolledPanel
 from rewx.util import exclude
 from rewx.bitmap_support import load, resize_image, to_bitmap
 from rewx.util import identity

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -784,27 +784,22 @@ def scrolledpanel(element, parent):
     panel = update(element, ScrolledPanel(parent))
     sizer = wx.BoxSizer(element['props'].get('orient', wx.VERTICAL))
     panel.SetSizer(sizer)
-    panel.last_scroll_pos = None
-    def handle_scroll(event):
-        # Save the scroll position so that it can be restored after update
-        panel.last_scroll_pos = panel.GetViewStart()
-        event.Skip() # Propagate this event
-    panel.Bind(wx.EVT_SCROLLWIN, handle_scroll)
     return panel
 
 @update.register(ScrolledPanel)
 def scrolledpanel(element, instance: ScrolledPanel):
     props = element['props']
     set_basic_props(instance, props)
-    instance.SetupScrolling(
-        scroll_x=props.get('scroll_x', False),
-        scroll_y=props.get('scroll_y', False)
-    )
-    # Restore the scroll position from before the update
-    if hasattr(instance, 'last_scroll_pos'):
-        if instance.last_scroll_pos:
-            # This works but it flickers because the widgets aren't frozen.
-            wx.CallAfter(instance.Scroll, instance.last_scroll_pos)
+    scroll_x=props.get('scroll_x', False)
+    scroll_y=props.get('scroll_y', False)
+    # Only call SetupScrolling if the props changed.
+    if not hasattr(instance, 'last_scroll_x') or instance.last_scroll_x != scroll_x or not hasattr(instance, 'last_scroll_y') or instance.last_scroll_y != scroll_y:
+        instance.SetupScrolling(
+            scroll_x=scroll_x,
+            scroll_y=scroll_y
+        )
+    instance.last_scroll_x=scroll_x
+    instance.last_scroll_y=scroll_y
     instance.Unbind(wx.EVT_LEFT_DOWN)
     if 'on_click' in props:
         instance.Bind(wx.EVT_LEFT_DOWN, props['on_click'])

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -826,22 +826,47 @@ def scrolledpanel(element, parent):
 def scrolledpanel(element, instance: ScrolledPanel):
     props = element['props']
     set_basic_props(instance, props)
-    scroll_x=props.get('scroll_x', False)
-    scroll_y=props.get('scroll_y', False)
     # Only call SetupScrolling if the props changed.
-    if not hasattr(instance, 'last_scroll_x') or instance.last_scroll_x != scroll_x or not hasattr(instance, 'last_scroll_y') or instance.last_scroll_y != scroll_y:
+    # https://docs.wxpython.org/wx.lib.scrolledpanel.ScrolledPanel.html#wx.lib.scrolledpanel.ScrolledPanel.SetupScrolling
+    # https://github.com/wxWidgets/Phoenix/blob/de0a4415c05e7483b2960c6dc9720154269244a8/wx/lib/scrolledpanel.py#L120
+    scroll_x = props.get('scroll_x', False)
+    scroll_y = props.get('scroll_y', False)
+    rate_x = props.get('rate_x', 20)
+    rate_y = props.get('rate_y', 20)
+    if (not hasattr(instance, 'last_scroll_x')
+        or instance.last_scroll_x != scroll_x
+        or not hasattr(instance, 'last_scroll_y')
+        or instance.last_scroll_y != scroll_y
+        or not hasattr(instance, 'last_rate_x')
+        or instance.last_rate_x != rate_x
+        or not hasattr(instance, 'last_rate_y')
+        or instance.last_rate_y != rate_y
+        ):
         instance.SetupScrolling(
             scroll_x=scroll_x,
-            scroll_y=scroll_y
+            scroll_y=scroll_y,
+            rate_x=rate_x,
+            rate_y=rate_y
         )
-    instance.last_scroll_x=scroll_x
-    instance.last_scroll_y=scroll_y
+    instance.last_scroll_x = scroll_x
+    instance.last_scroll_y = scroll_y
+    instance.last_rate_x = rate_x
+    instance.last_rate_y = rate_y
     instance.Unbind(wx.EVT_LEFT_DOWN)
     if 'on_click' in props:
         instance.Bind(wx.EVT_LEFT_DOWN, props['on_click'])
     instance.Unbind(wx.EVT_SIZE)
     if 'on_size' in props:
         instance.Bind(wx.EVT_SIZE, props['on_size'])
+    instance.Unbind(wx.EVT_MOTION)
+    if 'on_mouse_motion' in props:
+        instance.Bind(wx.EVT_MOTION, props['on_mouse_motion'])
+    instance.Unbind(wx.EVT_MOUSEWHEEL)
+    if 'on_mouse_wheel' in props:
+        instance.Bind(wx.EVT_MOUSEWHEEL, props['on_mouse_wheel'])
+    instance.Unbind(wx.EVT_SCROLLWIN)
+    if 'on_scrollwin' in props:
+        instance.Bind(wx.EVT_SCROLLWIN, props['on_scrollwin'])
     return instance
 
 

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -324,7 +324,8 @@ def file_picker_ctrl_open(element, instance: FilePickerCtrlOpen):
 
 @mount.register(FilePickerCtrlSave)
 def file_picker_ctrl_save(element, parent):
-    return update(element, FilePickerCtrlSave(parent, style=wx.FLP_SAVE))
+    props = element['props']
+    return update(element, FilePickerCtrlSave(parent, style=wx.FLP_SAVE, wildcard=props.get('wildcard', '*.*')))
 
 @update.register(FilePickerCtrlSave)
 def file_picker_ctrl_save(element, instance: FilePickerCtrlSave):

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -412,16 +412,31 @@ def listctrl(element, instance: wx.ListCtrl):
         del props['style']
     set_basic_props(instance, props)
     # TODO: what events...?
+    restored_widths = ListCtrl_GetColumnWidths(instance)
     instance.DeleteAllColumns()
     instance.DeleteAllItems()
     for e, col in enumerate(props.get('column_defs', [])):
         instance.InsertColumn(e, col['title'])
+    ListCtrl_SetColumnWidths(instance, restored_widths)
 
     for row_idx, item in enumerate(props.get('data', [])):
         instance.InsertItem(row_idx, '')
         for col_idx, coldef in enumerate(props.get('column_defs', [])):
             instance.SetItem(row_idx, col_idx, coldef['column'](item))
     return instance
+
+def ListCtrl_GetColumnWidths(instance: wx.ListCtrl):
+    wds = []
+    for i in range(0, instance.GetColumnCount()):
+        wds.append(instance.GetColumnWidth(i))
+    return wds
+
+def ListCtrl_SetColumnWidths(instance: wx.ListCtrl, wds: list[int]): # : List[int]):
+    # no-op if the list of column widths is the wrong length
+    if len(wds) == instance.GetColumnCount():
+        for i in range(0, len(wds)):
+            instance.SetColumnWidth(i, wds[i])
+
 
 
 @mount.register(wx.media.MediaCtrl)

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -764,6 +764,9 @@ def block(element, instance: Block):
     instance.Unbind(wx.EVT_LEFT_DOWN)
     if 'on_click' in props:
         instance.Bind(wx.EVT_LEFT_DOWN, props['on_click'])
+    instance.Unbind(wx.EVT_SIZE)
+    if 'on_size' in props:
+        instance.Bind(wx.EVT_SIZE, props['on_size'])
     return instance
 
 

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -140,13 +140,16 @@ def button(element, parent):
 def button(element, instance: wx.Button):
     props = element['props']
     set_basic_props(instance, props)
-    if props.get('enabled') is False:
-        # we navigate away from the control when disabling.
-        # Without this, under conditions where the button gets
-        # disabled / re-enabled quickly, wx will still feed events
-        # spawned while it was disable to the now recently enabled
-        # button. This behavior doesn't happen if we navigate away
-        instance.Navigate()
+    # Removed this behavior because I don't want it, and it causes a problem
+    # because the Button grabs focus on every render when disabled.
+    #
+    # if props.get('enabled') is False:
+    #     # we navigate away from the control when disabling.
+    #     # Without this, under conditions where the button gets
+    #     # disabled / re-enabled quickly, wx will still feed events
+    #     # spawned while it was disable to the now recently enabled
+    #     # button. This behavior doesn't happen if we navigate away
+    #     instance.Navigate()
     instance.Unbind(wx.EVT_BUTTON)
     if props.get('on_click'):
         instance.Bind(wx.EVT_BUTTON, props['on_click'])

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -939,6 +939,9 @@ def textctrl(element, instance: wx.TextCtrl):
     instance.Unbind(wx.EVT_KILL_FOCUS)
     if 'on_focus_kill' in props:
         instance.Bind(wx.EVT_KILL_FOCUS, props['on_focus_kill'])
+    instance.Unbind(wx.EVT_KEY_DOWN)
+    if 'on_key_down' in props:
+        instance.Bind(wx.EVT_KEY_DOWN, props['on_key_down'])
     return instance
 
 

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -133,8 +133,7 @@ def activity_indicator(element, instance: wx.ActivityIndicator):
 
 @mount.register(wx.Button)
 def button(element, parent):
-    default_style = 0
-    return update(element, wx.Button(parent, element['props'].get('style', default_style)))
+    return update(element, wx.Button(parent, style=element['props'].get('style', 0)))
 
 
 @update.register(wx.Button)

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -480,7 +480,7 @@ def ListCtrl_GetColumnWidths(instance: wx.ListCtrl):
         wds.append(instance.GetColumnWidth(i))
     return wds
 
-def ListCtrl_SetColumnWidths(instance: wx.ListCtrl, wds: list[int]): # : List[int]):
+def ListCtrl_SetColumnWidths(instance: wx.ListCtrl, wds: list[int]):
     # no-op if the list of column widths is the wrong length
     if len(wds) == instance.GetColumnCount():
         for i in range(0, len(wds)):

--- a/rewx/widgets.py
+++ b/rewx/widgets.py
@@ -279,7 +279,9 @@ def combobox(element, instance: wx.ComboBox) -> wx.Object:
 
 @mount.register(wx.DirPickerCtrl)
 def dir_picker_ctrl(element, parent):
-    return update(element, wx.DirPickerCtrl(parent))
+    instance = wx.DirPickerCtrl(parent)
+    instance.self_managed = True # DirPickerCtrl has a self-managed Button child.
+    return update(element, instance)
 
 @update.register(wx.DirPickerCtrl)
 def dir_picker_ctrl(element, instance: wx.DirPickerCtrl):
@@ -405,7 +407,9 @@ def listbox(element, instance: wx.ListBox):
 
 @mount.register(wx.ListCtrl)
 def listctrl(element, parent):
-    return update(element, wx.ListCtrl(parent, style=wx.LC_REPORT))
+    instance = wx.ListCtrl(parent, style=wx.LC_REPORT)
+    instance.self_managed = True
+    return update(element, instance)
 
 @update.register(wx.ListCtrl)
 def listctrl(element, instance: wx.ListCtrl):

--- a/tests/test_components/test_gauge.py
+++ b/tests/test_components/test_gauge.py
@@ -1,7 +1,6 @@
 import threading
 import wx
 import wx.lib.inspection
-from pip._vendor.contextlib2 import contextmanager
 from unittest import TestCase
 
 from rewx import create_element, wsx, render

--- a/tests/test_components/test_staticbitmap.py
+++ b/tests/test_components/test_staticbitmap.py
@@ -1,7 +1,6 @@
 import threading
 import wx
 import wx.lib.inspection
-from pip._vendor.contextlib2 import contextmanager
 from unittest import TestCase
 from unittest.mock import MagicMock
 


### PR DESCRIPTION
This has turned into an omni-PR for a lot of little improvements that I had to make in order use __re-wx__ for my (private, proprietary) project. In the end it all worked out and the project was finished and deployed.

### Widgets

New components:

* `FlexGrid`
* `FilePickerCtrlOpen` Resolves #11
* `FilePickerCtrlSave` Resolves #11
* `DirPickerCtrl` Resolves #11

Improved components:

* `ScrolledPanel`
* `Button`
* `ComboBox`
* `ListCtrl`
* `SpinCtrl`
* `SpinCtrlDouble`
* `Block`
* `StaticBitmap` Resolves #18

### Core 

* Empty child lists are allowed.
* The `patch` reconciliation can now correctly handle the case where the type of a child changes. (This is great news because this is where the real magic of a declarative TEA GUI really happens. This is why __re-wx__ is a generation better than [horrible static design domain-specific languages](https://kivy.org/doc/stable/gettingstarted/rules.html) ). (TODO We still don’t have [`'key'` props](https://reactjs.org/docs/reconciliation.html#keys) for performance.) Resolves #13
* `Layout()` each `Sizer` once for each `patch`. Resolves #15